### PR TITLE
fix: 计算充满列宽度时取到上一次的表格宽度，导致计算宽度错误

### DIFF
--- a/components/table/pipeline/features/autoFill.tsx
+++ b/components/table/pipeline/features/autoFill.tsx
@@ -107,7 +107,7 @@ function getColumnWidthSum (pipeline: TablePipeline) {
 }
 
 function getTableRemainingWidth (pipeline: TablePipeline) {
-  const tableWidth = pipeline.getStateAtKey(tableWidthKey)
+  const tableWidth = pipeline.ref.current.domHelper?.tableBody?.clientWidth || pipeline.getStateAtKey(tableWidthKey)
   if (!tableWidth) return
   const remainingWidth = Math.floor(tableWidth - getColumnWidthSum(pipeline))
   return remainingWidth > 0 ? remainingWidth : 0


### PR DESCRIPTION
@xiaolinsq 