### PR TITLE
fix: 范围框选初始状态不需要加上样式名

### DIFF
--- a/components/table/pipeline/features/rangeSelection.tsx
+++ b/components/table/pipeline/features/rangeSelection.tsx
@@ -221,7 +221,7 @@ export function rangeSelection (opts:RangeSelectionFeatureOptions) {
       }
     }
 
-    pipeline.addTableProps({ onMouseDown, onKeyDown, tabIndex: -1, className: cx([Classes.rangeSelection]) }) // todo: 后面可以把mousedown放到一个流里面
+    pipeline.addTableProps({ onMouseDown, onKeyDown, tabIndex: -1 }) // todo: 后面可以把mousedown放到一个流里面
 
     return pipeline.mapColumns(makeRecursiveMapper((col) => {
       const cellRanges = pipeline.getStateAtKey(rangeSelectionKey) || []


### PR DESCRIPTION
@wqhui 